### PR TITLE
Documentation Update: Node 7 Required

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GraphQL Starter Kit &nbsp; <a href="https://github.com/kriasoft/graphql-starter-kit/stargazers"><img src="https://img.shields.io/github/stars/kriasoft/graphql-starter-kit.svg?style=social&label=Star&maxAge=3600" height="20"></a> <a href="https://twitter.com/ReactStarter"><img src="https://img.shields.io/twitter/follow/ReactStarter.svg?style=social&label=Follow&maxAge=3600" height="20"></a>
 
 Project template for authoring **[GraphQL](http://graphql.org/)** server
-applications with **Node.js 6+** and **JavaScript** (**[demo](https://api.reactstarterkit.com)**).
+applications with **Node.js 7+** and **JavaScript** (**[demo](https://api.reactstarterkit.com)**).
 You can use it either as a playground or a base for your next Node.js-based backend project.
 
 


### PR DESCRIPTION
After Node 6 failed for me, I noticed that you changed the requirements to Node 7 in the travis.yml - once I upgraded to Node 7 everything worked.